### PR TITLE
Include subgenerators in "files"

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
     "test": "mocha"
   },
   "files": [
-    "app"
+    "app",
+    "ractive",
+    "component",
+    "lib"
   ],
   "keywords": [
     "yeoman-generator",


### PR DESCRIPTION
This change includes the ractive:ractive- and the ractive:component-generator in the "files"-property
to let them work as described in the documentation.
The "lib"-folder is also included in the change.
